### PR TITLE
Track bad debt

### DIFF
--- a/src/WormholeJoin.sol
+++ b/src/WormholeJoin.sol
@@ -177,8 +177,8 @@ contract WormholeJoin {
 
         // No need of overflow check here as amtToTake is bounded by wormholes[hashGUID].pending
         // which is already a uint248. Also int256 >> uint248. Then both castings are safe.
-        debt[wormholeGUID.sourceDomain]     +=  int256(amtToTake);
-        wormholes[hashGUID].pending         -= uint248(amtToTake);
+        debt[wormholeGUID.sourceDomain] +=  int256(amtToTake);
+        wormholes[hashGUID].pending     -= uint248(amtToTake);
 
         // Update debt running totals
         uint256 newDebt = Debt[wormholeGUID.sourceDomain] + amtToTake;

--- a/src/WormholeJoin.sol
+++ b/src/WormholeJoin.sol
@@ -266,12 +266,10 @@ contract WormholeJoin {
         rakes[sourceDomain] = daiSettled + badDebt;
         vat.suck(vow, address(this), badDebt * RAY);
 
-        if (vat.live() == 1) {
-            (, uint256 art) = vat.urns(ilk, address(this)); // rate == RAY => normalized debt == actual debt
-            uint256 amtToPayBack = _min(badDebt, art);
-            vat.frob(ilk, address(this), address(this), address(this), -int256(amtToPayBack), -int256(amtToPayBack));
-            vat.slip(ilk, address(this), -int256(amtToPayBack));
-        }
+        (, uint256 art) = vat.urns(ilk, address(this)); // rate == RAY => normalized debt == actual debt
+        uint256 amtToPayBack = _min(badDebt, art);
+        vat.frob(ilk, address(this), address(this), address(this), -int256(amtToPayBack), -int256(amtToPayBack));
+        vat.slip(ilk, address(this), -int256(amtToPayBack));
         debt[sourceDomain] -= int256(badDebt);  // Cast checked above
         emit Rectify(sourceDomain, era, badDebt);
     }


### PR DESCRIPTION
Basically you keep running totals of debt vs settlements for each source domain, and check if a repayment hasn't occurred within some `ttl`.

With this setup we get automated bad debt reconciliation, but we have to ensure that `settle(...)` is called with some regularity. Bad debt could also be reconciled manually with executive vote which would save gas on the common path.

TODO:

 * Considerations with longer `ttl`. May mask bad debt for a little while. Maybe that's okay?
 * Tests when they become available in `master`.