### PR TITLE
Switch to OZ enumerable set

### DIFF
--- a/src/WormholeRouter.sol
+++ b/src/WormholeRouter.sol
@@ -17,6 +17,7 @@
 pragma solidity 0.8.9;
 
 import "./WormholeGUID.sol";
+import "./utils/EnumerableSet.sol";
 
 interface TokenLike {
   function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
@@ -29,12 +30,13 @@ interface GatewayLike {
 
 contract WormholeRouter {
 
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
     mapping (address => uint256) public wards;          // Auth
     mapping (bytes32 => address) public gateways;       // GatewayLike contracts called by the router for each domain
     mapping (address => bytes32) public domains;        // Domains for each gateway
-    mapping (bytes32 => uint256) public domainIndices;  // The domain's position in the active domain array
 
-    bytes32[] public allDomains;  // Array of active domains
+    EnumerableSet.Bytes32Set private allDomains;
 
     TokenLike immutable public dai; // L1 DAI ERC20 token
 
@@ -71,8 +73,7 @@ contract WormholeRouter {
      * and L1 bridge contracts (for L2 domains).
      * @dev In addition to updating the mapping `gateways` which maps GatewayLike contracts to domain names and
      * the reverse mapping `domains` which maps domain names to GatewayLike contracts, this method also maintains
-     * an array `allDomains` of all active domains as well as a mapping `domainIndices` of the indices of domain names within
-     * the `allDomains` array. `domainIndices` is used to allow updating `allDomains` using only O(1) writes.
+     * the enumerable set `allDomains`.
      * @param what The name of the operation. Only "gateway" is supported.
      * @param domain The domain for which a GatewayLike contract is added, replaced or removed.
      * @param gateway The address of the GatewayLike contract to install for the domain (or address(0) to remove a domain)
@@ -83,23 +84,14 @@ contract WormholeRouter {
             if(prevGateway == address(0)) { 
                 // new domain => add it to allDomains
                 if(gateway != address(0)) {
-                    domainIndices[domain] = allDomains.length;
-                    allDomains.push(domain);
+                    allDomains.add(domain);
                 }
             } else { 
                 // existing domain 
                 domains[prevGateway] = bytes32(0);
                 if(gateway == address(0)) {
                     // => remove domain from allDomains
-                    uint256 pos = domainIndices[domain];
-                    uint256 lastIndex = allDomains.length - 1;
-                    if (pos != lastIndex) {
-                        bytes32 lastDomain = allDomains[lastIndex];
-                        allDomains[pos] = lastDomain;
-                        domainIndices[lastDomain] = pos;
-                    }
-                    allDomains.pop();
-                    delete domainIndices[domain];
+                    allDomains.remove(domain);
                 }
             }
 
@@ -113,8 +105,14 @@ contract WormholeRouter {
         emit File(what, domain, gateway);
     }
 
-    function numActiveDomains() external view returns (uint256) {
-        return allDomains.length;
+    function numDomains() external view returns (uint256) {
+        return allDomains.length();
+    }
+    function domainAt(uint256 index) external view returns (bytes32) {
+        return allDomains.at(index);
+    }
+    function hasDomain(bytes32 domain) external view returns (bool) {
+        return allDomains.contains(domain);
     }
 
     /**

--- a/src/test/WormholeRouter.t.sol
+++ b/src/test/WormholeRouter.t.sol
@@ -82,15 +82,14 @@ contract WormholeRouterTest is DSTest {
         address gateway1 = address(111);
         assertEq(router.gateways(domain1), address(0));
         assertEq(router.domains(gateway1), bytes32(0));
-        assertEq(router.numActiveDomains(), 0);
+        assertEq(router.numDomains(), 0);
 
         assertTrue(_tryFile("gateway", domain1, gateway1));
 
         assertEq(router.gateways(domain1), gateway1);
         assertEq(router.domains(gateway1), domain1);
-        assertEq(router.numActiveDomains(), 1);
-        assertEq(router.allDomains(0), domain1);
-        assertEq(router.domainIndices(domain1), 0);
+        assertEq(router.numDomains(), 1);
+        assertEq(router.domainAt(0), domain1);
 
         bytes32 domain2 = "newdom2";
         address gateway2 = address(222);
@@ -101,11 +100,9 @@ contract WormholeRouterTest is DSTest {
 
         assertEq(router.gateways(domain2), gateway2);
         assertEq(router.domains(gateway2), domain2);
-        assertEq(router.numActiveDomains(), 2);
-        assertEq(router.allDomains(0), domain1);
-        assertEq(router.allDomains(1), domain2);
-        assertEq(router.domainIndices(domain1), 0);
-        assertEq(router.domainIndices(domain2), 1);
+        assertEq(router.numDomains(), 2);
+        assertEq(router.domainAt(0), domain1);
+        assertEq(router.domainAt(1), domain2);
     }
 
     function testFileNewGatewayForExistingDomain() public {
@@ -114,9 +111,8 @@ contract WormholeRouterTest is DSTest {
         assertTrue(_tryFile("gateway", domain, gateway1));
         assertEq(router.gateways(domain), gateway1);
         assertEq(router.domains(gateway1), domain);
-        assertEq(router.numActiveDomains(), 1);
-        assertEq(router.allDomains(0), domain);
-        assertEq(router.domainIndices(domain), 0);
+        assertEq(router.numDomains(), 1);
+        assertEq(router.domainAt(0), domain);
         address gateway2 = address(222);
         
         assertTrue(_tryFile("gateway", domain, gateway2));
@@ -124,9 +120,8 @@ contract WormholeRouterTest is DSTest {
         assertEq(router.gateways(domain), gateway2);
         assertEq(router.domains(gateway1), bytes32(0));
         assertEq(router.domains(gateway2), domain);
-        assertEq(router.numActiveDomains(), 1);
-        assertEq(router.allDomains(0), domain);
-        assertEq(router.domainIndices(domain), 0);
+        assertEq(router.numDomains(), 1);
+        assertEq(router.domainAt(0), domain);
     }
 
     function testFileRemoveLastDomain() public {
@@ -135,17 +130,15 @@ contract WormholeRouterTest is DSTest {
         assertTrue(_tryFile("gateway", domain, gateway));
         assertEq(router.gateways(domain), gateway);
         assertEq(router.domains(gateway), domain);
-        assertEq(router.numActiveDomains(), 1);
-        assertEq(router.allDomains(0), domain);
-        assertEq(router.domainIndices(domain), 0);
+        assertEq(router.numDomains(), 1);
+        assertEq(router.domainAt(0), domain);
 
         // Remove last domain
         assertTrue(_tryFile("gateway", domain, address(0)));
 
         assertEq(router.gateways(domain), address(0));
         assertEq(router.domains(gateway), bytes32(0));
-        assertEq(router.numActiveDomains(), 0);
-        assertEq(router.domainIndices(domain), 0);
+        assertTrue(!router.hasDomain(domain));
     }
 
 
@@ -160,11 +153,9 @@ contract WormholeRouterTest is DSTest {
         assertEq(router.gateways(domain2), gateway2);
         assertEq(router.domains(gateway1), domain1);
         assertEq(router.domains(gateway2), domain2);
-        assertEq(router.numActiveDomains(), 2);
-        assertEq(router.allDomains(0), domain1);
-        assertEq(router.allDomains(1), domain2);
-        assertEq(router.domainIndices(domain1), 0);
-        assertEq(router.domainIndices(domain2), 1);
+        assertEq(router.numDomains(), 2);
+        assertEq(router.domainAt(0), domain1);
+        assertEq(router.domainAt(1), domain2);
         
         // Remove first domain
         assertTrue(_tryFile("gateway", domain1, address(0)));
@@ -173,10 +164,8 @@ contract WormholeRouterTest is DSTest {
         assertEq(router.gateways(domain2), gateway2);
         assertEq(router.domains(gateway1), bytes32(0));
         assertEq(router.domains(gateway2), domain2);
-        assertEq(router.numActiveDomains(), 1);
-        assertEq(router.allDomains(0), domain2);
-        assertEq(router.domainIndices(domain1), 0);
-        assertEq(router.domainIndices(domain2), 0);
+        assertEq(router.numDomains(), 1);
+        assertEq(router.domainAt(0), domain2);
 
         // Re-add removed domain
         assertTrue(_tryFile("gateway", domain1, gateway1));
@@ -185,11 +174,9 @@ contract WormholeRouterTest is DSTest {
         assertEq(router.gateways(domain2), gateway2);
         assertEq(router.domains(gateway1), domain1);
         assertEq(router.domains(gateway2), domain2);
-        assertEq(router.numActiveDomains(), 2);
-        assertEq(router.allDomains(0), domain2); // domains have been swapped compared to initial state
-        assertEq(router.allDomains(1), domain1);
-        assertEq(router.domainIndices(domain1), 1); // indices have been swapped compared to initial state
-        assertEq(router.domainIndices(domain2), 0);
+        assertEq(router.numDomains(), 2);
+        assertEq(router.domainAt(0), domain2); // domains have been swapped compared to initial state
+        assertEq(router.domainAt(1), domain1);
     }
 
     function testFailFileInvalidWhat() public {

--- a/src/utils/EnumerableSet.sol
+++ b/src/utils/EnumerableSet.sol
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/structs/EnumerableSet.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Library for managing
+ * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
+ * types.
+ *
+ * Sets have the following properties:
+ *
+ * - Elements are added, removed, and checked for existence in constant time
+ * (O(1)).
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ *
+ * ```
+ * contract Example {
+ *     // Add the library methods
+ *     using EnumerableSet for EnumerableSet.AddressSet;
+ *
+ *     // Declare a set state variable
+ *     EnumerableSet.AddressSet private mySet;
+ * }
+ * ```
+ *
+ * As of v3.3.0, sets of type `bytes32` (`Bytes32Set`), `address` (`AddressSet`)
+ * and `uint256` (`UintSet`) are supported.
+ */
+library EnumerableSet {
+    // To implement this library for multiple types with as little code
+    // repetition as possible, we write it in terms of a generic Set type with
+    // bytes32 values.
+    // The Set implementation uses private functions, and user-facing
+    // implementations (such as AddressSet) are just wrappers around the
+    // underlying Set.
+    // This means that we can only create new EnumerableSets for types that fit
+    // in bytes32.
+
+    struct Set {
+        // Storage of set values
+        bytes32[] _values;
+        // Position of the value in the `values` array, plus 1 because index 0
+        // means a value is not in the set.
+        mapping(bytes32 => uint256) _indexes;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function _add(Set storage set, bytes32 value) private returns (bool) {
+        if (!_contains(set, value)) {
+            set._values.push(value);
+            // The value is stored at length-1, but we add 1 to all indexes
+            // and use 0 as a sentinel value
+            set._indexes[value] = set._values.length;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function _remove(Set storage set, bytes32 value) private returns (bool) {
+        // We read and store the value's index to prevent multiple reads from the same storage slot
+        uint256 valueIndex = set._indexes[value];
+
+        if (valueIndex != 0) {
+            // Equivalent to contains(set, value)
+            // To delete an element from the _values array in O(1), we swap the element to delete with the last one in
+            // the array, and then remove the last element (sometimes called as 'swap and pop').
+            // This modifies the order of the array, as noted in {at}.
+
+            uint256 toDeleteIndex = valueIndex - 1;
+            uint256 lastIndex = set._values.length - 1;
+
+            if (lastIndex != toDeleteIndex) {
+                bytes32 lastvalue = set._values[lastIndex];
+
+                // Move the last value to the index where the value to delete is
+                set._values[toDeleteIndex] = lastvalue;
+                // Update the index for the moved value
+                set._indexes[lastvalue] = valueIndex; // Replace lastvalue's index to valueIndex
+            }
+
+            // Delete the slot where the moved value was stored
+            set._values.pop();
+
+            // Delete the index for the deleted slot
+            delete set._indexes[value];
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function _contains(Set storage set, bytes32 value) private view returns (bool) {
+        return set._indexes[value] != 0;
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function _length(Set storage set) private view returns (uint256) {
+        return set._values.length;
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function _at(Set storage set, uint256 index) private view returns (bytes32) {
+        return set._values[index];
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function _values(Set storage set) private view returns (bytes32[] memory) {
+        return set._values;
+    }
+
+    // Bytes32Set
+
+    struct Bytes32Set {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _add(set._inner, value);
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _remove(set._inner, value);
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(Bytes32Set storage set, bytes32 value) internal view returns (bool) {
+        return _contains(set._inner, value);
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(Bytes32Set storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
+        return _at(set._inner, index);
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(Bytes32Set storage set) internal view returns (bytes32[] memory) {
+        return _values(set._inner);
+    }
+
+    // AddressSet
+
+    struct AddressSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(AddressSet storage set, address value) internal returns (bool) {
+        return _add(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(AddressSet storage set, address value) internal returns (bool) {
+        return _remove(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(AddressSet storage set, address value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(AddressSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(AddressSet storage set, uint256 index) internal view returns (address) {
+        return address(uint160(uint256(_at(set._inner, index))));
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(AddressSet storage set) internal view returns (address[] memory) {
+        bytes32[] memory store = _values(set._inner);
+        address[] memory result;
+
+        assembly {
+            result := store
+        }
+
+        return result;
+    }
+
+    // UintSet
+
+    struct UintSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(UintSet storage set, uint256 value) internal returns (bool) {
+        return _add(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(UintSet storage set, uint256 value) internal returns (bool) {
+        return _remove(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(UintSet storage set, uint256 value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function length(UintSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+    /**
+     * @dev Returns the value stored at position `index` in the set. O(1).
+     *
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+        return uint256(_at(set._inner, index));
+    }
+
+    /**
+     * @dev Return the entire set in an array
+     *
+     * WARNING: This operation will copy the entire storage to memory, which can be quite expensive. This is designed
+     * to mostly be used by view accessors that are queried without any gas fees. Developers should keep in mind that
+     * this function has an unbounded cost, and using it as part of a state-changing function may render the function
+     * uncallable if the set grows to a point where copying to memory consumes too much gas to fit in a block.
+     */
+    function values(UintSet storage set) internal view returns (uint256[] memory) {
+        bytes32[] memory store = _values(set._inner);
+        uint256[] memory result;
+
+        assembly {
+            result := store
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Implementing https://github.com/makerdao/dss-wormhole/issues/43. Instead of rolling our own data structures let's use the OZ one because the year is not 2016. Gas overhead is not really an issue in `file()`, and we will be less prone to making errors this way. I know it goes somewhat against minimal code design. We could always strip out the unused functions for Etherscan submission. Overall I'd like to find more of a happy middle ground between inline everything and massive import/inheritance messes.