### PR TITLE
Add TrustedRelay

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,8 @@ mkShell {
 
   shellHook = ''
     export NIX_SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+    export DAPP_BUILD_OPTIMIZE=1
+    export DAPP_BUILD_OPTIMIZE_RUNS=200
     unset SSL_CERT_FILE
   '';
 }

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -86,14 +86,14 @@ contract TrustedRelay {
     }
 
     function addSigners(address[] calldata signers_) external auth {
-        for(uint i; i < signers_.length; i++) {
+        for(uint256 i; i < signers_.length; i++) {
             signers[signers_[i]] = 1;
         }
         emit SignersAdded(signers_);
     }
 
     function removeSigners(address[] calldata signers_) external auth {
-        for(uint i; i < signers_.length; i++) {
+        for(uint256 i; i < signers_.length; i++) {
             signers[signers_[i]] = 0;
         }
         emit SignersRemoved(signers_);
@@ -128,7 +128,7 @@ contract TrustedRelay {
             keccak256(abi.encode(getGUIDHash(wormholeGUID), maxFeePercentage, gasFee, expiry))
         ));
         address recovered = ecrecover(signHash, v, r, s);
-        require(signers[recovered] == 1, "TrustedRelay/invalid-signature");
+        require(signers[recovered] == 1 || bytes32ToAddress(wormholeGUID.receiver) == recovered, "TrustedRelay/invalid-signature");
 
         // Initiate mint and mark the wormhole as done
         (uint256 postFeeAmount, uint256 totalFee) = oracleAuth.requestMint(wormholeGUID, signatures, maxFeePercentage, gasFee);

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.13;
+
+import "../WormholeGUID.sol";
+
+interface DaiJoinLike {
+    function dai() external view returns (TokenLike);
+    function exit(address, uint256) external;
+    function join(address, uint256) external;
+}
+
+interface TokenLike {
+    function balanceOf(address) external view returns (uint256);
+    function transfer(address, uint256) external returns (bool);
+}
+
+interface WormholeOracleAuthLike {
+    function requestMint(
+        WormholeGUID calldata wormholeGUID,
+        bytes calldata signatures,
+        uint256 maxFeePercentage,
+        uint256 operatorFee
+    ) external returns (uint256 postFeeAmount, uint256 totalFee);
+    function wormholeJoin() external view returns (WormholeJoinLike);
+}
+
+interface WormholeJoinLike {
+    function wormholes(bytes32 hashGUID) external view returns (bool, uint248);
+}
+
+// Relay messages automatically on the target domain
+// User provides gasFee which is paid to the msg.sender
+// Relay requests are signed by a trusted third-party (typically a backend orchestrating the withdrawal on behalf of the user)
+contract TrustedRelay {
+
+    mapping (address => uint256) public wards;   // Auth
+    mapping (address => uint256) public signers; // Trusted signers
+    
+    DaiJoinLike            public immutable daiJoin;
+    TokenLike              public immutable dai;
+    WormholeOracleAuthLike public immutable oracleAuth;
+    WormholeJoinLike       public immutable wormholeJoin;
+
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event SignersAdded(address[] signers);
+    event SignersRemoved(address[] signers);
+
+    modifier auth {
+        require(wards[msg.sender] == 1, "TrustedRelay/non-authed");
+        _;
+    }
+
+    constructor(address _oracleAuth, address _daiJoin) {
+        wards[msg.sender] = 1;
+        emit Rely(msg.sender);
+        oracleAuth = WormholeOracleAuthLike(_oracleAuth);
+        daiJoin = DaiJoinLike(_daiJoin);
+        dai = daiJoin.dai();
+        wormholeJoin = oracleAuth.wormholeJoin();
+    }
+
+    function rely(address usr) external auth {
+        wards[usr] = 1;
+        emit Rely(usr);
+    }
+
+    function deny(address usr) external auth {
+        wards[usr] = 0;
+        emit Deny(usr);
+    }
+
+    function addSigners(address[] calldata signers_) external auth {
+        for(uint i; i < signers_.length; i++) {
+            signers[signers_[i]] = 1;
+        }
+        emit SignersAdded(signers_);
+    }
+
+    function removeSigners(address[] calldata signers_) external auth {
+        for(uint i; i < signers_.length; i++) {
+            signers[signers_[i]] = 0;
+        }
+        emit SignersRemoved(signers_);
+    }
+
+    /**
+     * @notice Gasless relay for the Oracle fast path
+     * The final signature is ABI-encoded `hashGUID`, `maxFeePercentage`, `gasFee`, `expiry`
+     * @param wormholeGUID The wormhole GUID
+     * @param signatures The byte array of concatenated signatures ordered by increasing signer addresses.
+     * Each signature is {bytes32 r}{bytes32 s}{uint8 v}
+     * @param maxFeePercentage Max percentage of the withdrawn amount (in WAD) to be paid as fee (e.g 1% = 0.01 * WAD)
+     * @param gasFee DAI gas fee (in WAD)
+     * @param expiry Maximum time for when the query is valid
+     * @param v Part of ECDSA signature
+     * @param r Part of ECDSA signature
+     * @param s Part of ECDSA signature
+     */
+    function relay(
+        WormholeGUID calldata wormholeGUID,
+        bytes calldata signatures,
+        uint256 maxFeePercentage,
+        uint256 gasFee,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(block.timestamp <= expiry, "TrustedRelay/expired");
+        bytes32 signHash = keccak256(abi.encodePacked(
+            "\x19Ethereum Signed Message:\n32", 
+            keccak256(abi.encode(getGUIDHash(wormholeGUID), maxFeePercentage, gasFee, expiry))
+        ));
+        address recovered = ecrecover(signHash, v, r, s);
+        require(signers[recovered] == 1, "TrustedRelay/invalid-signature");
+
+        // Initiate mint and mark the wormhole as done
+        (uint256 postFeeAmount, uint256 totalFee) = oracleAuth.requestMint(wormholeGUID, signatures, maxFeePercentage, gasFee);
+        require(postFeeAmount + totalFee == wormholeGUID.amount, "TrustedRelay/partial-mint-disallowed");
+
+        // Send the gas fee to the relayer
+        dai.transfer(msg.sender, gasFee);
+    }
+
+}

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -60,9 +60,10 @@ contract TrustedRelay {
     WormholeOracleAuthLike public immutable oracleAuth;
     WormholeJoinLike       public immutable wormholeJoin;
     DsValueLike            public immutable ethPriceOracle;
-    uint256                public immutable gasMargin; // in RAY (e.g 150% = 1.5 * RAY)
+    uint256                public immutable gasMargin; // in BPS (e.g 150% = 15000)
 
-    uint256 constant public RAD = 10 ** 45;
+    uint256 constant public BPS = 10 ** 4;
+    uint256 constant public WAD = 10 ** 18;
 
     event Rely(address indexed usr);
     event Deny(address indexed usr);
@@ -158,7 +159,7 @@ contract TrustedRelay {
 
         // If the eth price oracle is enabled, use its value to check that gasFee is within an allowable margin
         (bytes32 ethPrice, bool ok) = ethPriceOracle.peek();
-        require(!ok || gasFee * RAD <= uint256(ethPrice) * gasMargin * gasprice() * (startGas - gasleft()), "TrustedRelay/excessive-gas-fee");
+        require(!ok || gasFee * WAD <= uint256(ethPrice) * gasMargin * gasprice() * (startGas - gasleft()) / BPS, "TrustedRelay/excessive-gas-fee");
     }
 
     function requestMint(

--- a/src/relays/TrustedRelay.sol
+++ b/src/relays/TrustedRelay.sol
@@ -62,8 +62,7 @@ contract TrustedRelay {
     DsValueLike            public immutable ethPriceOracle;
     uint256                public immutable gasMargin; // in BPS (e.g 150% = 15000)
 
-    uint256 constant public BPS = 10 ** 4;
-    uint256 constant public WAD = 10 ** 18;
+    uint256 constant public WAD_BPS = 10 ** 22; // WAD * BPS = 10^18 * 10^4
 
     event Rely(address indexed usr);
     event Deny(address indexed usr);
@@ -159,7 +158,7 @@ contract TrustedRelay {
 
         // If the eth price oracle is enabled, use its value to check that gasFee is within an allowable margin
         (bytes32 ethPrice, bool ok) = ethPriceOracle.peek();
-        require(!ok || gasFee * WAD <= uint256(ethPrice) * gasMargin * gasprice() * (startGas - gasleft()) / BPS, "TrustedRelay/excessive-gas-fee");
+        require(!ok || gasFee * WAD_BPS <= uint256(ethPrice) * gasMargin * gasprice() * (startGas - gasleft()), "TrustedRelay/excessive-gas-fee");
     }
 
     function requestMint(

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2021 Dai Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.8.13;
+
+import "ds-test/test.sol";
+
+import "src/WormholeGUID.sol";
+import "src/relays/TrustedRelay.sol";
+
+import "../mocks/VatMock.sol";
+import "../mocks/DaiMock.sol";
+import "../mocks/DaiJoinMock.sol";
+
+interface Hevm {
+    function warp(uint) external;
+    function addr(uint) external returns (address);
+    function sign(uint, bytes32) external returns (uint8, bytes32, bytes32);
+}
+
+contract WormholeJoinMock {
+
+    mapping (bytes32 => WormholeStatus) public wormholes;
+
+    DaiMock public dai;
+    uint256 public maxMint;
+
+    struct WormholeStatus {
+        bool    blessed;
+        uint248 pending;
+    }
+
+    constructor(DaiMock _dai) {
+        dai = _dai;
+    }
+
+    function setMaxMint(uint256 amt) external {
+        maxMint = amt;
+    }
+
+    function requestMint(
+        WormholeGUID calldata wormholeGUID,
+        uint256,
+        uint256 operatorFee
+    ) external returns (uint256 postFeeAmount, uint256 totalFee) {
+        bytes32 hashGUID = getGUIDHash(wormholeGUID);
+
+        // Take 1%
+        uint256 amount = wormholeGUID.amount;
+        if (amount > maxMint) amount = maxMint;
+        uint256 fee = amount * 1 / 100;
+        uint256 remainder = amount - fee;
+
+        wormholes[hashGUID].blessed = true;
+        wormholes[hashGUID].pending = uint248(wormholeGUID.amount - amount);
+
+        // Mint the DAI and send it to /operator
+        dai.mint(bytes32ToAddress(wormholeGUID.receiver), remainder - operatorFee);
+        dai.mint(bytes32ToAddress(wormholeGUID.operator), operatorFee);
+
+        return (remainder - operatorFee, fee + operatorFee);
+    }
+}
+
+contract WormholeOracleAuthMock {
+
+    WormholeJoinMock public join;
+
+    constructor(WormholeJoinMock _join) {
+        join = _join;
+    }
+
+    function requestMint(
+        WormholeGUID calldata wormholeGUID,
+        bytes calldata,
+        uint256 maxFeePercentage,
+        uint256 operatorFee
+    ) external returns (uint256 postFeeAmount, uint256 totalFee) {
+        return join.requestMint(wormholeGUID, maxFeePercentage, operatorFee);
+    }
+
+    function wormholeJoin() external view returns (address) {
+        return address(join);
+    }
+}
+
+contract TrustedRelayTest is DSTest {
+
+    uint256 internal constant WAD = 10**18;
+
+    Hevm internal hevm = Hevm(HEVM_ADDRESS);
+
+    TrustedRelay internal relay;
+    VatMock internal vat;
+    DaiMock internal dai;
+    DaiJoinMock internal daiJoin;
+    WormholeJoinMock internal join;
+    WormholeOracleAuthMock internal oracleAuth;
+
+    function getSignHash(
+        WormholeGUID memory wormholeGUID,
+        uint256 maxFeePercentage,
+        uint256 gasFee,
+        uint256 expiry
+    ) internal pure returns (bytes32 signHash) {
+        signHash = keccak256(abi.encodePacked(
+            "\x19Ethereum Signed Message:\n32", 
+            keccak256(abi.encode(getGUIDHash(wormholeGUID), maxFeePercentage, gasFee, expiry))
+        ));
+    }
+
+    function setUp() public {
+        vat = new VatMock();
+        dai = new DaiMock();
+        daiJoin = new DaiJoinMock(address(vat), address(dai));
+        join = new WormholeJoinMock(dai);
+        oracleAuth = new WormholeOracleAuthMock(join);
+        relay = new TrustedRelay(address(oracleAuth), address(daiJoin));
+        join.setMaxMint(100 ether);
+    }
+
+    function test_constructor_args() public {
+        assertEq(address(relay.daiJoin()), address(daiJoin));
+        assertEq(address(relay.dai()), address(dai));
+        assertEq(address(relay.oracleAuth()), address(oracleAuth));
+        assertEq(address(relay.wormholeJoin()), address(join));
+    }
+
+    function testAddRemoveSigners() public {
+        address[] memory signers = new address[](3);
+        for(uint i; i < signers.length; i++) {
+            signers[i] = address(uint160(i));
+            assertEq(relay.signers(address(uint160(i))), 0);
+        }
+
+        relay.addSigners(signers);
+
+        for(uint i; i < signers.length; i++) {
+            assertEq(relay.signers(address(uint160(i))), 1);
+        }
+
+        relay.removeSigners(signers);
+
+        for(uint i; i < signers.length; i++) {
+            assertEq(relay.signers(address(uint160(i))), 0);
+        }
+    }
+
+    function test_relay() public {
+        uint256 sk = uint(keccak256(abi.encode(8)));
+        address[] memory signers = new address[](1);
+        signers[0] = hevm.addr(sk);
+        relay.addSigners(signers);
+        address receiver = address(123);
+        WormholeGUID memory guid = WormholeGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        assertEq(dai.balanceOf(receiver), 0);
+        assertEq(dai.balanceOf(address(this)), 0);
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+        // Should get 100 DAI - 1% wormhole fee - 1 DAI gas fee
+        assertEq(dai.balanceOf(receiver), 98 ether);
+        assertEq(dai.balanceOf(address(this)), 1 ether);
+    }
+
+    function testFail_relay_expired() public {
+        uint256 sk = uint(keccak256(abi.encode(8)));
+        address[] memory signers = new address[](1);
+        signers[0] = hevm.addr(sk);
+        relay.addSigners(signers);
+        address receiver = address(123);
+        WormholeGUID memory guid = WormholeGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        hevm.warp(block.timestamp + 1);
+
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+    }
+
+    function testFail_relay_bad_signature() public {
+        uint256 sk = uint(keccak256(abi.encode(8)));
+        address[] memory signers = new address[](1);
+        signers[0] = hevm.addr(sk);
+        relay.addSigners(signers);
+        address receiver = address(123);
+        WormholeGUID memory guid = WormholeGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage + 1,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+    }
+
+    function testFail_relay_bad_signer() public {
+        address receiver = address(123);
+        WormholeGUID memory guid = WormholeGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage + 1,
+            gasFee,
+            expiry
+        );
+
+        uint256 sk = uint(keccak256(abi.encode(888)));
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+    }
+
+    function testFail_relay_partial_mint() public {
+        join.setMaxMint(50 ether);
+
+        uint256 sk = uint(keccak256(abi.encode(8)));
+        address[] memory signers = new address[](1);
+        signers[0] = hevm.addr(sk);
+        relay.addSigners(signers);
+        address receiver = address(123);
+        WormholeGUID memory guid = WormholeGUID({
+            sourceDomain: "l2network",
+            targetDomain: "ethereum",
+            receiver: addressToBytes32(receiver),
+            operator: addressToBytes32(address(relay)),
+            amount: 100 ether,
+            nonce: 5,
+            timestamp: uint48(block.timestamp)
+        });
+        uint256 maxFeePercentage = WAD * 1 / 100;   // 1%
+        uint256 gasFee = WAD;                       // 1 DAI of gas
+        uint256 expiry = block.timestamp;
+        bytes32 signHash = getSignHash(
+            guid,
+            maxFeePercentage,
+            gasFee,
+            expiry
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = hevm.sign(sk, signHash);
+
+        relay.relay(
+            guid,
+            "",     // Not testing OracleAuth signatures here
+            maxFeePercentage,
+            gasFee,
+            expiry,
+            v,
+            r,
+            s
+        );
+    }
+}

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -130,8 +130,8 @@ contract ExampleContract {
 
 contract TrustedRelayTest is DSTest {
 
+    uint256 internal constant BPS = 10**4;
     uint256 internal constant WAD = 10**18;
-    uint256 internal constant RAY = 10**27;
 
     Hevm internal hevm = Hevm(HEVM_ADDRESS);
 
@@ -166,7 +166,7 @@ contract TrustedRelayTest is DSTest {
         ext = new ExampleContract();
         ethPriceOracle = new DSValueMock();
         ethPriceOracle.poke(bytes32(3000 * WAD));
-        relay = new TrustedRelayMock(address(oracleAuth), address(daiJoin), address(ethPriceOracle), 150 * RAY / 100);
+        relay = new TrustedRelayMock(address(oracleAuth), address(daiJoin), address(ethPriceOracle), 150 * BPS / 100);
         join.setMaxMint(100 ether);
     }
 

--- a/src/test/relays/TrustedRelay.t.sol
+++ b/src/test/relays/TrustedRelay.t.sol
@@ -221,7 +221,7 @@ contract TrustedRelayTest is DSTest {
         assertTrue(!_tryDeny(address(456)));
     }
 
-        function testFileFailsWhenNotAuthed() public {
+    function testFileFailsWhenNotAuthed() public {
         assertTrue(_tryFile("margin", 888));
         relay.deny(address(this));
         assertTrue(!_tryFile("margin", 888));


### PR DESCRIPTION
Adds a trusted relay contract that allows relay requests to be signed by a trusted third-party. This can be used by integrators requiring the relay request to be signed by a trusted backend key.

Notes:

- The contract optionally allows the execution of an external call after the DAI minting to facilitate the composition of the withdrawal with other operations (e.g. AMM swap).

- The contract relies on an ETH price oracle to verify that the refund gasFee (in DAI) is within an acceptable margin considering the `tx.gasprice`. As Dapptools doesn't support changing `tx.gasprice` in tests, we wrap `tx.gasprice` in an virtual function that is overriden in tests. It's worth keeping track of https://github.com/foundry-rs/foundry/pull/1383 which would support setting `tx.gasprice` in foundry tests.